### PR TITLE
fix: Use UTC timezone for consistent image file names.

### DIFF
--- a/internal/exifdata/exif.go
+++ b/internal/exifdata/exif.go
@@ -40,7 +40,11 @@ func GetExifTime(path string) (time.Time, error) {
 
 	// Parse string into Time
 	// TODO: Parse timezone
-	return time.Parse(exifDateLayout, value)
+	t, err := time.Parse(exifDateLayout, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t.UTC(), nil
 }
 
 func getTimeFromTag(exifIfd *exif.Ifd) (value string, err error) {

--- a/internal/media/sorter.go
+++ b/internal/media/sorter.go
@@ -183,7 +183,7 @@ func (s *sorter) getFileTimestamp(path string) (ts time.Time, err error) {
 	if err != nil {
 		return time.Time{}, fmt.Errorf("%w: %w", errRuntime, err)
 	}
-	return ts, nil
+	return ts.UTC(), nil
 }
 
 func (s *sorter) getOutputFile(ts time.Time, srcPath string) (string, error) {


### PR DESCRIPTION
## Before this PR
The output file names used were not explicitly set to always be in UTC

## After this PR
Explicitly set timezones in UTC. 