### PR TITLE
improvement: Don't modify existing extension character casing if magic-out flag is not set.

### DIFF
--- a/cmd/sort.go
+++ b/cmd/sort.go
@@ -59,10 +59,10 @@ func shortRun(_ *cobra.Command, _ []string) {
 		opts = append(opts, mediasort.WithLastModifiedFallback())
 	}
 	if magicSignatureIn {
-		opts = append(opts, mediasort.WithIdentifyFileMagicSignature())
+		opts = append(opts, mediasort.WithInputFileMagicSignature())
 	}
 	if magicSignatureOut {
-		opts = append(opts, mediasort.WithGenOutputFileMagicSignature())
+		opts = append(opts, mediasort.WithOutputFileMagicSignature())
 	}
 	if detectDuplicates {
 		opts = append(opts, mediasort.WithDetectDuplicates())

--- a/internal/mediasort/file_handler.go
+++ b/internal/mediasort/file_handler.go
@@ -14,10 +14,10 @@ import (
 )
 
 type metadataFileHandler struct {
-	useMagicSignature bool
-	dryRun            bool
-	detectDuplicates  bool
-	overwriteExisting bool
+	useInputMagicSignature bool
+	dryRun                 bool
+	detectDuplicates       bool
+	overwriteExisting      bool
 
 	mediaMetadataVisitorFunc mediatype.VisitorFunc[string]
 }
@@ -104,7 +104,7 @@ func (s *metadataFileHandler) shouldSkip(ctx context.Context, srcMedia mediatype
 }
 
 func (s *metadataFileHandler) isDuplicateImage(ctx context.Context, srcMedia mediatype.Format, outPath string) (bool, error) {
-	outMedia, err := mediatype.ID(outPath, s.useMagicSignature)
+	outMedia, err := mediatype.ID(outPath, s.useInputMagicSignature)
 	if err != nil {
 		return false, err
 	}

--- a/internal/mediasort/traverse.go
+++ b/internal/mediasort/traverse.go
@@ -15,10 +15,10 @@ import (
 type traverser struct {
 	sourceDirectory string
 
-	stopWalkOnError   bool
-	allowedFileTypes  []string
-	blocklist         []*regexp.Regexp
-	useMagicSignature bool
+	stopWalkOnError        bool
+	allowedFileTypes       []string
+	blocklist              []*regexp.Regexp
+	useInputMagicSignature bool
 
 	fileHandler    *metadataFileHandler
 	extVisitorFunc mediatype.VisitorFunc[map[string]struct{}]
@@ -55,7 +55,7 @@ func (t *traverser) traverseFunc(ctx context.Context) fs.WalkDirFunc {
 			return fs.SkipDir
 		}
 
-		srcMedia, err := mediatype.ID(path, t.useMagicSignature)
+		srcMedia, err := mediatype.ID(path, t.useInputMagicSignature)
 		if err != nil {
 			logger.Debug("Could not identify file as media file.", zap.Error(err))
 			return nil

--- a/internal/visitors/metadata_filename.go
+++ b/internal/visitors/metadata_filename.go
@@ -17,17 +17,17 @@ const (
 )
 
 type mediaMetadataFilename struct {
-	outDir                      *string
-	useLastModifiedDate         bool
-	timestampAsFilename         bool
-	useOutputMagicFileSignature bool
+	outDir                  *string
+	useLastModifiedDate     bool
+	timestampAsFilename     bool
+	useOutputMagicSignature bool
 }
 
 // NewMediaMetadataFilename is a mediatype visitor that will generated an appropriate
 // output filename for a provided mediatype format.
 // - useLastModifiedDate: Fallback to using the last modified date if no EXIF data exists on the media
 // - timestampAsFilename: Use the Unix EPOCH time as the output file name.
-// - useOutputMagicFileSignature: Use the identified mediatype Ext as the extension of the output filename
+// - useOutputMagicSignature: Use the identified mediatype Ext as the extension of the output filename
 // TODO(dtrejo): Rename useLastModifiedDate to fallbackToLastModifiedDate to
 // better describe what this variable actually does.
 func NewMediaMetadataFilename(
@@ -35,13 +35,13 @@ func NewMediaMetadataFilename(
 	outDir *string,
 	useLastModifiedDate,
 	timestampAsFilename,
-	useOutputMagicFileSignature bool,
+	useOutputMagicSignature bool,
 ) mediatype.VisitorFunc[string] {
 	return &mediaMetadataFilename{
-		outDir:                      outDir,
-		useLastModifiedDate:         useLastModifiedDate,
-		timestampAsFilename:         timestampAsFilename,
-		useOutputMagicFileSignature: useOutputMagicFileSignature,
+		outDir:                  outDir,
+		useLastModifiedDate:     useLastModifiedDate,
+		timestampAsFilename:     timestampAsFilename,
+		useOutputMagicSignature: useOutputMagicSignature,
 	}
 }
 
@@ -82,7 +82,7 @@ func (e *mediaMetadataFilename) getOutputFile(_ context.Context, srcPath, cleanE
 	}
 
 	ext := filepath.Ext(srcPath)
-	if e.useOutputMagicFileSignature {
+	if e.useOutputMagicSignature {
 		ext = cleanExt
 	}
 	outFilename := strings.TrimSuffix(filepath.Base(srcPath), filepath.Ext(srcPath))

--- a/internal/visitors/metadata_filename.go
+++ b/internal/visitors/metadata_filename.go
@@ -17,17 +17,17 @@ const (
 )
 
 type mediaMetadataFilename struct {
-	outDir              *string
-	useLastModifiedDate bool
-	timestampAsFilename bool
-	cleanOutFileExt     bool
+	outDir                      *string
+	useLastModifiedDate         bool
+	timestampAsFilename         bool
+	useOutputMagicFileSignature bool
 }
 
 // NewMediaMetadataFilename is a mediatype visitor that will generated an appropriate
 // output filename for a provided mediatype format.
 // - useLastModifiedDate: Fallback to using the last modified date if no EXIF data exists on the media
 // - timestampAsFilename: Use the Unix EPOCH time as the output file name.
-// - cleanOutFileExt: Use the identified mediatype Ext as the extension of the output filename
+// - useOutputMagicFileSignature: Use the identified mediatype Ext as the extension of the output filename
 // TODO(dtrejo): Rename useLastModifiedDate to fallbackToLastModifiedDate to
 // better describe what this variable actually does.
 func NewMediaMetadataFilename(
@@ -35,13 +35,13 @@ func NewMediaMetadataFilename(
 	outDir *string,
 	useLastModifiedDate,
 	timestampAsFilename,
-	cleanOutFileExt bool,
+	useOutputMagicFileSignature bool,
 ) mediatype.VisitorFunc[string] {
 	return &mediaMetadataFilename{
-		outDir:              outDir,
-		useLastModifiedDate: useLastModifiedDate,
-		timestampAsFilename: timestampAsFilename,
-		cleanOutFileExt:     cleanOutFileExt,
+		outDir:                      outDir,
+		useLastModifiedDate:         useLastModifiedDate,
+		timestampAsFilename:         timestampAsFilename,
+		useOutputMagicFileSignature: useOutputMagicFileSignature,
 	}
 }
 
@@ -81,8 +81,8 @@ func (e *mediaMetadataFilename) getOutputFile(_ context.Context, srcPath, cleanE
 		outDir = filepath.Join(*e.outDir, ts.Format(outPathDateFormat))
 	}
 
-	ext := filepath.Ext(strings.ToLower(srcPath))
-	if e.cleanOutFileExt {
+	ext := filepath.Ext(srcPath)
+	if e.useOutputMagicFileSignature {
 		ext = cleanExt
 	}
 	outFilename := strings.TrimSuffix(filepath.Base(srcPath), filepath.Ext(srcPath))


### PR DESCRIPTION
Also rename variable names throughout for consistently between flag names and variable names.