### PR TITLE
fix: Add mov and mp4 to default supported filetypes.

### DIFF
--- a/internal/mediasort/builder.go
+++ b/internal/mediasort/builder.go
@@ -21,6 +21,8 @@ var (
 		"png",
 		"heif",
 		"tiff",
+		"mov",
+		"mp4",
 	}
 	// DefaultBlocklist are default regexes that are ignored by the sorter.
 	DefaultBlocklist = []*regexp.Regexp{

--- a/internal/mediasort/builder.go
+++ b/internal/mediasort/builder.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/dtrejod/goexif/internal/ilog"
+	"github.com/dtrejod/goexif/internal/mediatype"
 	"github.com/dtrejod/goexif/internal/visitors"
 	"go.uber.org/zap"
 )
@@ -16,13 +17,12 @@ var (
 	// DefaultFileTypes are the default media types handled by the sorter if none are specified.
 	// NOTE: This default list should match the known mediatypes in the ./internal/mediatype package.
 	DefaultFileTypes = []string{
-		"jpg",
-		"jpeg",
-		"png",
-		"heif",
-		"tiff",
-		"mov",
-		"mp4",
+		mediatype.JPEG{}.String(),
+		mediatype.PNG{}.String(),
+		mediatype.HEIF{}.String(),
+		mediatype.TIFF{}.String(),
+		mediatype.QTFF{}.String(),
+		mediatype.MP4{}.String(),
 	}
 	// DefaultBlocklist are default regexes that are ignored by the sorter.
 	DefaultBlocklist = []*regexp.Regexp{


### PR DESCRIPTION
FLUP to https://github.com/dtrejod/goexif/pull/21