### PR TITLE
improvement: Add support for parsing keys and creation date from under ilst atom.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,4 +31,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a
+replace github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24

--- a/go.mod
+++ b/go.mod
@@ -30,5 +30,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24

--- a/go.mod
+++ b/go.mod
@@ -30,3 +30,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dtrejod/goexif
 go 1.20
 
 require (
-	github.com/abema/go-mp4 v1.1.1
+	github.com/abema/go-mp4 v1.2.0
 	github.com/corona10/goimagehash v1.1.0
 	github.com/dsoprea/go-exif/v3 v3.0.1
 	github.com/h2non/filetype v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/dsoprea/go-utility/v2 v2.0.0-20221003142440-7a1927d49d9d/go.mod h1:LV
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003160719-7bc88537c05e/go.mod h1:VZ7cB0pTjm1ADBWhJUOHESu4ZYy9JN+ZPqjfiW09EPU=
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003172846-a3e1774ef349 h1:DilThiXje0z+3UQ5YjYiSRRzVdtamFpvBQXKwMglWqw=
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003172846-a3e1774ef349/go.mod h1:4GC5sXji84i/p+irqghpPFZBF8tRN/Q7+700G0/DLe8=
-github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24 h1:QqN4jHLXFZ2/cLzUiJFyeqqzGnHukVQM/UHGL9sxkyY=
-github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/go-errors/errors v1.1.1/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/dsoprea/go-utility/v2 v2.0.0-20221003142440-7a1927d49d9d/go.mod h1:LV
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003160719-7bc88537c05e/go.mod h1:VZ7cB0pTjm1ADBWhJUOHESu4ZYy9JN+ZPqjfiW09EPU=
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003172846-a3e1774ef349 h1:DilThiXje0z+3UQ5YjYiSRRzVdtamFpvBQXKwMglWqw=
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003172846-a3e1774ef349/go.mod h1:4GC5sXji84i/p+irqghpPFZBF8tRN/Q7+700G0/DLe8=
-github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a h1:7ihKAyDDHyWXxZKuhQi+PlqJYoJ1Mt35SaZt3Z9OD/M=
-github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
+github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24 h1:QqN4jHLXFZ2/cLzUiJFyeqqzGnHukVQM/UHGL9sxkyY=
+github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/go-errors/errors v1.1.1/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/abema/go-mp4 v1.1.1 h1:OfzkdMO6SWTBR1ltNSVwlTHatrAK9I3iYLQfkdEMMuc=
-github.com/abema/go-mp4 v1.1.1/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/corona10/goimagehash v1.1.0 h1:teNMX/1e+Wn/AYSbLHX8mj+mF9r60R1kBeqE9MkoYwI=
 github.com/corona10/goimagehash v1.1.0/go.mod h1:VkvE0mLn84L4aF8vCb6mafVajEb6QYMHl2ZJLn0mOGI=
@@ -25,6 +23,8 @@ github.com/dsoprea/go-utility/v2 v2.0.0-20221003142440-7a1927d49d9d/go.mod h1:LV
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003160719-7bc88537c05e/go.mod h1:VZ7cB0pTjm1ADBWhJUOHESu4ZYy9JN+ZPqjfiW09EPU=
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003172846-a3e1774ef349 h1:DilThiXje0z+3UQ5YjYiSRRzVdtamFpvBQXKwMglWqw=
 github.com/dsoprea/go-utility/v2 v2.0.0-20221003172846-a3e1774ef349/go.mod h1:4GC5sXji84i/p+irqghpPFZBF8tRN/Q7+700G0/DLe8=
+github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a h1:7ihKAyDDHyWXxZKuhQi+PlqJYoJ1Mt35SaZt3Z9OD/M=
+github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
 github.com/go-errors/errors v1.1.1/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/abema/go-mp4 v1.2.0 h1:gi4X8xg/m179N/J15Fn5ugywN9vtI6PLk6iLldHGLAk=
+github.com/abema/go-mp4 v1.2.0/go.mod h1:vPl9t5ZK7K0x68jh12/+ECWBCXoWuIDtNgPtU2f04ws=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/corona10/goimagehash v1.1.0 h1:teNMX/1e+Wn/AYSbLHX8mj+mF9r60R1kBeqE9MkoYwI=
 github.com/corona10/goimagehash v1.1.0/go.mod h1:VkvE0mLn84L4aF8vCb6mafVajEb6QYMHl2ZJLn0mOGI=

--- a/internal/moovdata/moov.go
+++ b/internal/moovdata/moov.go
@@ -8,29 +8,10 @@ import (
 	mp4 "github.com/abema/go-mp4"
 )
 
-const (
-	ilstItemDateLayout = "2006-01-02T15:04:05-0700"
-)
-
 var (
-	// handledBoxes are the set of boxes that we will expand
-	handledBoxes map[mp4.BoxType]struct{} = map[mp4.BoxType]struct{}{
-		mp4.BoxTypeMoov(): {},
-		// mvhd box will contain creation time
-		// Ref: https://developer.apple.com/documentation/quicktime-file-format/movie_header_atom/creation_time
-		mp4.BoxTypeMvhd(): {},
-		// meta box will contain ilst item where 1 item may contain creation time
-		mp4.BoxTypeMeta(): {},
-		mp4.BoxTypeKeys(): {},
-		mp4.BoxTypeIlst(): {},
-	}
-	// handledChildBoxes are the set of boxes that we will expand if the
-	// parent was one of the following from the BoxPath. Any item in this
-	// list should also be in handledBoxes in order to pickup the children
-	// of the box
-	handledChildBoxes map[mp4.BoxType]struct{} = map[mp4.BoxType]struct{}{
-		mp4.BoxTypeIlst(): {},
-	}
+	// mvhdBoxPath is the BoxPath to the MVHD Box that contains Creation Time metadata
+	// Ref: https://developer.apple.com/documentation/quicktime-file-format/movie_header_atom/creation_time
+	mvhdBoxPath mp4.BoxPath = []mp4.BoxType{mp4.BoxTypeMoov(), mp4.BoxTypeMvhd()}
 )
 
 // GetTime return the CreationTime from a MooV file
@@ -43,47 +24,13 @@ func GetTime(path string) (time.Time, error) {
 }
 
 func getTimeFromBoxes(boxes []*mp4.BoxInfoWithPayload) (time.Time, error) {
-	var creationDateIlstIdx *int
-	itemIdx := 0
-
-	var ilstTs *time.Time
-	var mvhdTs *time.Time
 	for _, box := range boxes {
 		switch t := box.Payload.(type) {
-		case *mp4.Keys:
-			for i, k := range t.Entries {
-				if string(k.KeyNamespace) == "mdta" && string(k.KeyValue) == "com.apple.quicktime.creationdate" {
-					// ilst items are not zero indexed so add 1
-					idx := i + 1
-					creationDateIlstIdx = &idx
-				}
-			}
-		case *mp4.Item:
-			itemIdx++
-			if creationDateIlstIdx != nil && itemIdx == *creationDateIlstIdx {
-				ts, err := time.Parse(ilstItemDateLayout, string(t.Data.Data[:]))
-				if err != nil {
-					// unexpected error but swallow in case we find a mvhd timestamp
-					continue
-				}
-				ilstTs = &ts
-			}
 		case *mp4.Mvhd:
-			ts := timeSince1904(t.CreationTimeV0)
-			mvhdTs = &ts
-		default:
+			return timeSince1904(t.CreationTimeV0), nil
 		}
 	}
-
-	// prefer ilst timestamp
-	if ilstTs != nil {
-		return (*ilstTs).UTC(), nil
-	}
-	if mvhdTs != nil {
-		return (*mvhdTs).UTC(), nil
-	}
-
-	return time.Time{}, errors.New("could not find box from known mp4 boxes that contains a valid timestamp")
+	return time.Time{}, errors.New("could not find mvhd box from known mp4 boxes")
 }
 
 func getMetadataBoxes(path string) ([]*mp4.BoxInfoWithPayload, error) {
@@ -93,43 +40,7 @@ func getMetadataBoxes(path string) ([]*mp4.BoxInfoWithPayload, error) {
 	}
 	defer f.Close()
 
-	var bis []*mp4.BoxInfo
-	_, err = mp4.ReadBoxStructure(f, func(h *mp4.ReadHandle) (interface{}, error) {
-		_, handled := handledBoxes[h.BoxInfo.Type]
-
-		handledChild := false
-		if len(h.Path) > 1 {
-			_, handledChild = handledChildBoxes[h.Path[len(h.Path)-2]]
-		}
-
-		if handled || handledChild {
-			bis = append(bis, &h.BoxInfo)
-
-			// Expands children
-			return h.Expand()
-		}
-		return nil, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	bs := make([]*mp4.BoxInfoWithPayload, 0, len(bis))
-	for _, bi := range bis {
-		if _, err := bi.SeekToPayload(f); err != nil {
-			return nil, err
-		}
-
-		box, _, err := mp4.UnmarshalAny(f, bi.Type, bi.Size-bi.HeaderSize, bi.Context)
-		if err != nil {
-			return nil, err
-		}
-		bs = append(bs, &mp4.BoxInfoWithPayload{
-			Info:    *bi,
-			Payload: box,
-		})
-	}
-	return bs, nil
+	return mp4.ExtractBoxesWithPayload(f, nil, []mp4.BoxPath{mvhdBoxPath})
 }
 
 // timeSince1904 returns the time from the provided 32-bit int. CreationTime in

--- a/internal/moovdata/moov.go
+++ b/internal/moovdata/moov.go
@@ -2,7 +2,6 @@ package moovdata
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"time"
 
@@ -81,7 +80,6 @@ func getTimeFromBoxes(boxes []*mp4.BoxInfoWithPayload) (time.Time, error) {
 		return (*ilstTs).UTC(), nil
 	}
 	if mvhdTs != nil {
-		fmt.Println("mvhd")
 		return (*mvhdTs).UTC(), nil
 	}
 
@@ -95,15 +93,13 @@ func getMetadataBoxes(path string) ([]*mp4.BoxInfoWithPayload, error) {
 	}
 	defer f.Close()
 
-	var handledChild bool
 	var bis []*mp4.BoxInfo
 	_, err = mp4.ReadBoxStructure(f, func(h *mp4.ReadHandle) (interface{}, error) {
 		_, handled := handledBoxes[h.BoxInfo.Type]
 
+		handledChild := false
 		if len(h.Path) > 1 {
 			_, handledChild = handledChildBoxes[h.Path[len(h.Path)-2]]
-		} else {
-			handledChild = false
 		}
 
 		if handled || handledChild {
@@ -121,6 +117,9 @@ func getMetadataBoxes(path string) ([]*mp4.BoxInfoWithPayload, error) {
 		}
 		return nil, nil
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	bs := make([]*mp4.BoxInfoWithPayload, 0, len(bis))
 	for _, bi := range bis {

--- a/internal/moovdata/moov.go
+++ b/internal/moovdata/moov.go
@@ -9,16 +9,29 @@ import (
 	mp4 "github.com/abema/go-mp4"
 )
 
+const (
+	ilstItemDateLayout = "2006-01-02T15:04:05-0700"
+)
+
 var (
-	// mvhdBoxPath is the BoxPath to the MVHD Box that contains Creation Time metadata
-	// Ref: https://developer.apple.com/documentation/quicktime-file-format/movie_header_atom/creation_time
-	mvhdBoxPath mp4.BoxPath = []mp4.BoxType{mp4.BoxTypeMoov(), mp4.BoxTypeMvhd()}
-	// keysBoxPath is the BoxPath to the Keys Box. A keys box's type should
-	// be intepreted before any other fields in Meta box so we can identifiy a proper index for items in ilst
-	// Ref: https://developer.apple.com/documentation/quicktime-file-format/metadata_handler_atom
-	keysBoxPath mp4.BoxPath = []mp4.BoxType{mp4.BoxTypeMoov(), mp4.BoxTypeMeta(), mp4.BoxTypeKeys()}
-	// ilstBoxAnyPath is the BoxPath to an AnyBoxI under ilst.
-	ilstBoxAnyPath mp4.BoxPath = []mp4.BoxType{mp4.BoxTypeMoov(), mp4.BoxTypeMeta(), mp4.BoxTypeIlst(), mp4.BoxTypeAny()}
+	// handledBoxes are the set of boxes that we will expand
+	handledBoxes map[mp4.BoxType]struct{} = map[mp4.BoxType]struct{}{
+		mp4.BoxTypeMoov(): {},
+		// mvhd box will contain creation time
+		// Ref: https://developer.apple.com/documentation/quicktime-file-format/movie_header_atom/creation_time
+		mp4.BoxTypeMvhd(): {},
+		// meta box will contain ilst item where 1 item may contain creation time
+		mp4.BoxTypeMeta(): {},
+		mp4.BoxTypeKeys(): {},
+		mp4.BoxTypeIlst(): {},
+	}
+	// handledChildBoxes are the set of boxes that we will expand if the
+	// parent was one of the following from the BoxPath. Any item in this
+	// list should also be in handledBoxes in order to pickup the children
+	// of the box
+	handledChildBoxes map[mp4.BoxType]struct{} = map[mp4.BoxType]struct{}{
+		mp4.BoxTypeIlst(): {},
+	}
 )
 
 // GetTime return the CreationTime from a MooV file
@@ -34,29 +47,45 @@ func getTimeFromBoxes(boxes []*mp4.BoxInfoWithPayload) (time.Time, error) {
 	var creationDateIlstIdx *int
 	itemIdx := 0
 
-	fmt.Println("boxes", boxes)
+	var ilstTs *time.Time
+	var mvhdTs *time.Time
 	for _, box := range boxes {
-		fmt.Printf("box: %+v\n", box)
 		switch t := box.Payload.(type) {
 		case *mp4.Keys:
 			for i, k := range t.Entries {
 				if string(k.KeyNamespace) == "mdta" && string(k.KeyValue) == "com.apple.quicktime.creationdate" {
-					idx := i
+					// ilst items are not zero indexed so add 1
+					idx := i + 1
 					creationDateIlstIdx = &idx
 				}
 			}
-		case *mp4.Data:
-			fmt.Println("item")
+		case *mp4.Item:
 			itemIdx++
 			if creationDateIlstIdx != nil && itemIdx == *creationDateIlstIdx {
-				fmt.Println(string(t.Data))
+				ts, err := time.Parse(ilstItemDateLayout, string(t.Data.Data[:]))
+				if err != nil {
+					// unexpected error but swallow in case we find a mvhd timestamp
+					continue
+				}
+				ilstTs = &ts
 			}
 		case *mp4.Mvhd:
-			// TODO: Use mvhd block creation date as fallback
-			//return timeSince1904(t.CreationTimeV0), nil
+			ts := timeSince1904(t.CreationTimeV0)
+			mvhdTs = &ts
+		default:
 		}
 	}
-	return time.Time{}, errors.New("could not find mvhd box from known mp4 boxes")
+
+	// prefer ilst timestamp
+	if ilstTs != nil {
+		return (*ilstTs).UTC(), nil
+	}
+	if mvhdTs != nil {
+		fmt.Println("mvhd")
+		return (*mvhdTs).UTC(), nil
+	}
+
+	return time.Time{}, errors.New("could not find box from known mp4 boxes that contains a valid timestamp")
 }
 
 func getMetadataBoxes(path string) ([]*mp4.BoxInfoWithPayload, error) {
@@ -66,10 +95,49 @@ func getMetadataBoxes(path string) ([]*mp4.BoxInfoWithPayload, error) {
 	}
 	defer f.Close()
 
-	return mp4.ExtractBoxesWithPayload(f, nil, []mp4.BoxPath{
-		keysBoxPath,
-		ilstBoxAnyPath,
-		mvhdBoxPath})
+	var handledChild bool
+	var bis []*mp4.BoxInfo
+	_, err = mp4.ReadBoxStructure(f, func(h *mp4.ReadHandle) (interface{}, error) {
+		_, handled := handledBoxes[h.BoxInfo.Type]
+
+		if len(h.Path) > 1 {
+			_, handledChild = handledChildBoxes[h.Path[len(h.Path)-2]]
+		} else {
+			handledChild = false
+		}
+
+		if handled || handledChild {
+			// set if underIlst on box context for parsing box code below
+			if len(h.Path) > 0 {
+				if h.Path[len(h.Path)-1] == mp4.BoxTypeIlst() {
+					h.BoxInfo.Context.UnderIlst = true
+				}
+			}
+
+			bis = append(bis, &h.BoxInfo)
+
+			// Expands children
+			return h.Expand()
+		}
+		return nil, nil
+	})
+
+	bs := make([]*mp4.BoxInfoWithPayload, 0, len(bis))
+	for _, bi := range bis {
+		if _, err := bi.SeekToPayload(f); err != nil {
+			return nil, err
+		}
+
+		box, _, err := mp4.UnmarshalAny(f, bi.Type, bi.Size-bi.HeaderSize, bi.Context)
+		if err != nil {
+			return nil, err
+		}
+		bs = append(bs, &mp4.BoxInfoWithPayload{
+			Info:    *bi,
+			Payload: box,
+		})
+	}
+	return bs, nil
 }
 
 // timeSince1904 returns the time from the provided 32-bit int. CreationTime in

--- a/internal/moovdata/moov.go
+++ b/internal/moovdata/moov.go
@@ -103,13 +103,6 @@ func getMetadataBoxes(path string) ([]*mp4.BoxInfoWithPayload, error) {
 		}
 
 		if handled || handledChild {
-			// set if underIlst on box context for parsing box code below
-			if len(h.Path) > 0 {
-				if h.Path[len(h.Path)-1] == mp4.BoxTypeIlst() {
-					h.BoxInfo.Context.UnderIlst = true
-				}
-			}
-
 			bis = append(bis, &h.BoxInfo)
 
 			// Expands children

--- a/vendor/github.com/abema/go-mp4/README.md
+++ b/vendor/github.com/abema/go-mp4/README.md
@@ -6,8 +6,13 @@ go-mp4
 [![Coverage Status](https://coveralls.io/repos/github/abema/go-mp4/badge.svg)](https://coveralls.io/github/abema/go-mp4)
 [![Go Report Card](https://goreportcard.com/badge/github.com/abema/go-mp4)](https://goreportcard.com/report/github.com/abema/go-mp4)
 
-go-mp4 is Go library and CLI tool which provide low-level I/O interfaces of MP4.
+go-mp4 is Go library which provides low-level I/O interfaces of MP4.
 This library supports you to parse or build any MP4 boxes(atoms) directly.
+
+go-mp4 provides very flexible interfaces for reading boxes.
+If you want to read only specific parts of MP4 file, this library extracts those boxes via io.ReadSeeker interface.
+
+On the other hand, this library is not suitable for complex data conversions.
 
 ## Integration with your Go application
 

--- a/vendor/github.com/abema/go-mp4/box_info.go
+++ b/vendor/github.com/abema/go-mp4/box_info.go
@@ -12,6 +12,9 @@ type Context struct {
 	// IsQuickTimeCompatible represents whether ftyp.compatible_brands contains "qt  ".
 	IsQuickTimeCompatible bool
 
+	// QuickTimeKeysMetaEntryCount the expected number of items under the ilst box as observed from the keys box
+	QuickTimeKeysMetaEntryCount int
+
 	// UnderWave represents whether current box is under the wave box.
 	UnderWave bool
 

--- a/vendor/github.com/abema/go-mp4/box_types_iso23001_5.go
+++ b/vendor/github.com/abema/go-mp4/box_types_iso23001_5.go
@@ -1,0 +1,35 @@
+package mp4
+
+/*************************** ipcm ****************************/
+
+func BoxTypeIpcm() BoxType { return StrToBoxType("ipcm") }
+
+func init() {
+	AddAnyTypeBoxDef(&AudioSampleEntry{}, BoxTypeIpcm())
+}
+
+/*************************** fpcm ****************************/
+
+func BoxTypeFpcm() BoxType { return StrToBoxType("fpcm") }
+
+func init() {
+	AddAnyTypeBoxDef(&AudioSampleEntry{}, BoxTypeFpcm())
+}
+
+/*************************** pcmC ****************************/
+
+func BoxTypePcmC() BoxType { return StrToBoxType("pcmC") }
+
+func init() {
+	AddBoxDef(&PcmC{}, 0, 1)
+}
+
+type PcmC struct {
+	FullBox       `mp4:"0,extend"`
+	FormatFlags   uint8 `mp4:"1,size=8"`
+	PCMSampleSize uint8 `mp4:"1,size=8"`
+}
+
+func (PcmC) GetType() BoxType {
+	return BoxTypePcmC()
+}

--- a/vendor/github.com/abema/go-mp4/box_types_metadata.go
+++ b/vendor/github.com/abema/go-mp4/box_types_metadata.go
@@ -75,12 +75,6 @@ func init() {
 	for _, bt := range ilstMetaBoxTypes {
 		AddAnyTypeBoxDefEx(&IlstMetaContainer{}, bt, isIlstMetaContainer)
 	}
-	// NOTE: Theoretically the number of keys can go up to 0xFFFFFFFF but
-	// we avoid initializing that many keys BoxTypes. Instead we
-	// handle up to 1024 keys
-	for i := uint32(0); i < 1024; i++ {
-		AddAnyTypeBoxDefEx(&Item{}, Uint32ToBoxType(i), isIlstMetaContainer)
-	}
 	AddAnyTypeBoxDefEx(&StringData{}, StrToBoxType("mean"), isUnderIlstFreeFormat)
 	AddAnyTypeBoxDefEx(&StringData{}, StrToBoxType("name"), isUnderIlstFreeFormat)
 }
@@ -175,7 +169,9 @@ func (sd *StringData) StringifyField(name string, indent string, depth int, ctx 
 	return "", false
 }
 
-// Item is a item under an item list
+/*************************** numbered items ****************************/
+
+// Item is a numbered item under an item list atom
 // https://developer.apple.com/documentation/quicktime-file-format/metadata_item_list_atom/item_list
 type Item struct {
 	AnyTypeBox
@@ -227,6 +223,8 @@ func (k *Keys) GetFieldLength(name string, ctx Context) uint {
 	}
 	panic(fmt.Errorf("invalid name of dynamic-length field: boxType=keys fieldName=%s", name))
 }
+
+/*************************** key ****************************/
 
 // Key is a key value field in the Keys BoxType
 // https://developer.apple.com/documentation/quicktime-file-format/metadata_item_keys_atom/key_value_key_size-8

--- a/vendor/github.com/abema/go-mp4/box_types_metadata.go
+++ b/vendor/github.com/abema/go-mp4/box_types_metadata.go
@@ -75,6 +75,12 @@ func init() {
 	for _, bt := range ilstMetaBoxTypes {
 		AddAnyTypeBoxDefEx(&IlstMetaContainer{}, bt, isIlstMetaContainer)
 	}
+	// NOTE: Theoretically the number of keys can go up to 0xFFFFFFFF but
+	// we avoid initializing that many keys BoxTypes. Instead we
+	// handle up to 1024 keys
+	for i := uint32(0); i < 1024; i++ {
+		AddAnyTypeBoxDefEx(&Item{}, Uint32ToBoxType(i), isIlstMetaContainer)
+	}
 	AddAnyTypeBoxDefEx(&StringData{}, StrToBoxType("mean"), isUnderIlstFreeFormat)
 	AddAnyTypeBoxDefEx(&StringData{}, StrToBoxType("name"), isUnderIlstFreeFormat)
 }
@@ -107,6 +113,8 @@ const (
 	DataTypeFloat64BigEndian   = 23
 )
 
+// Data is a Value BoxType
+// https://developer.apple.com/documentation/quicktime-file-format/value_atom
 type Data struct {
 	Box
 	DataType uint32 `mp4:"0,size=32"`
@@ -167,6 +175,85 @@ func (sd *StringData) StringifyField(name string, indent string, depth int, ctx 
 	return "", false
 }
 
+// Item is a item under an item list
+// https://developer.apple.com/documentation/quicktime-file-format/metadata_item_list_atom/item_list
+type Item struct {
+	AnyTypeBox
+	Version  uint8   `mp4:"0,size=8"`
+	Flags    [3]byte `mp4:"1,size=8"`
+	ItemName []byte  `mp4:"2,size=8,len=4"`
+	Data     Data    `mp4:"3"`
+}
+
+// StringifyField returns field value as string
+func (i *Item) StringifyField(name string, indent string, depth int, ctx Context) (string, bool) {
+	switch name {
+	case "ItemName":
+		return fmt.Sprintf("\"%s\"", util.EscapeUnprintables(string(i.ItemName))), true
+	}
+	return "", false
+}
+
 func isUnderIlstFreeFormat(ctx Context) bool {
 	return ctx.UnderIlstFreeMeta
+}
+
+func BoxTypeKeys() BoxType { return StrToBoxType("keys") }
+
+func init() {
+	AddBoxDef(&Keys{})
+}
+
+/*************************** keys ****************************/
+
+// Keys is the Keys BoxType
+// https://developer.apple.com/documentation/quicktime-file-format/metadata_item_keys_atom
+type Keys struct {
+	FullBox    `mp4:"0,extend"`
+	EntryCount int32 `mp4:"1,size=32"`
+	Entries    []Key `mp4:"2,len=dynamic"`
+}
+
+// GetType implements the IBox interface and returns the BoxType
+func (*Keys) GetType() BoxType {
+	return BoxTypeKeys()
+}
+
+// GetFieldLength implements the ICustomFieldObject interface and returns the length of dynamic fields
+func (k *Keys) GetFieldLength(name string, ctx Context) uint {
+	switch name {
+	case "Entries":
+		return uint(k.EntryCount)
+	}
+	panic(fmt.Errorf("invalid name of dynamic-length field: boxType=keys fieldName=%s", name))
+}
+
+// Key is a key value field in the Keys BoxType
+// https://developer.apple.com/documentation/quicktime-file-format/metadata_item_keys_atom/key_value_key_size-8
+type Key struct {
+	BaseCustomFieldObject
+	KeySize      int32  `mp4:"0,size=32"`
+	KeyNamespace []byte `mp4:"1,size=8,len=4"`
+	KeyValue     []byte `mp4:"2,size=8,len=dynamic"`
+}
+
+// GetFieldLength implements the ICustomFieldObject interface and returns the length of dynamic fields
+func (k *Key) GetFieldLength(name string, ctx Context) uint {
+	switch name {
+	case "KeyValue":
+		// sizeOf(KeySize)+sizeOf(KeyNamespace) = 8 bytes
+		return uint(k.KeySize) - 8
+	}
+	panic(fmt.Errorf("invalid name of dynamic-length field: boxType=key fieldName=%s", name))
+}
+
+// StringifyField returns field value as string
+func (k *Key) StringifyField(name string, indent string, depth int, ctx Context) (string, bool) {
+	switch name {
+	case "KeyNamespace":
+		return fmt.Sprintf("\"%s\"", util.EscapeUnprintables(string(k.KeyNamespace))), true
+	case "KeyValue":
+		return fmt.Sprintf("\"%s\"", util.EscapeUnprintables(string(k.KeyValue))), true
+	}
+	return "", false
 }

--- a/vendor/github.com/abema/go-mp4/mp4.go
+++ b/vendor/github.com/abema/go-mp4/mp4.go
@@ -108,6 +108,17 @@ func (boxType BoxType) getBoxDef(ctx Context) *boxDef {
 			return boxDef
 		}
 	}
+	if ctx.UnderIlst {
+		typeID := int(binary.BigEndian.Uint32(boxType[:]))
+		if typeID >= 1 && typeID <= ctx.QuickTimeKeysMetaEntryCount {
+			payload := &Item{}
+			return &boxDef{
+				dataType: reflect.TypeOf(payload).Elem(),
+				isTarget: isIlstMetaContainer,
+				fields:   buildFields(payload),
+			}
+		}
+	}
 	return nil
 }
 

--- a/vendor/github.com/abema/go-mp4/mp4.go
+++ b/vendor/github.com/abema/go-mp4/mp4.go
@@ -100,6 +100,8 @@ func AddAnyTypeBoxDefEx(payload IAnyType, boxType BoxType, isTarget func(Context
 	})
 }
 
+var itemBoxFields = buildFields(&Item{})
+
 func (boxType BoxType) getBoxDef(ctx Context) *boxDef {
 	boxDefs := boxMap[boxType]
 	for i := len(boxDefs) - 1; i >= 0; i-- {
@@ -111,11 +113,10 @@ func (boxType BoxType) getBoxDef(ctx Context) *boxDef {
 	if ctx.UnderIlst {
 		typeID := int(binary.BigEndian.Uint32(boxType[:]))
 		if typeID >= 1 && typeID <= ctx.QuickTimeKeysMetaEntryCount {
-			payload := &Item{}
 			return &boxDef{
-				dataType: reflect.TypeOf(payload).Elem(),
+				dataType: reflect.TypeOf(Item{}),
 				isTarget: isIlstMetaContainer,
-				fields:   buildFields(payload),
+				fields:   itemBoxFields,
 			}
 		}
 	}

--- a/vendor/github.com/abema/go-mp4/mp4.go
+++ b/vendor/github.com/abema/go-mp4/mp4.go
@@ -1,6 +1,7 @@
 package mp4
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"reflect"
@@ -17,6 +18,13 @@ func StrToBoxType(code string) BoxType {
 		panic(fmt.Errorf("invalid box type id length: [%s]", code))
 	}
 	return BoxType{code[0], code[1], code[2], code[3]}
+}
+
+// Uint32ToBoxType returns a new BoxType from the provied uint32
+func Uint32ToBoxType(i uint32) BoxType {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, i)
+	return BoxType{b[0], b[1], b[2], b[3]}
 }
 
 func (boxType BoxType) String() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -88,4 +88,3 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
-# github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a
+# github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24
 ## explicit; go 1.14
 github.com/abema/go-mp4
 github.com/abema/go-mp4/internal/bitio

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24
+# github.com/abema/go-mp4 v1.2.0
 ## explicit; go 1.14
 github.com/abema/go-mp4
 github.com/abema/go-mp4/internal/bitio
@@ -88,3 +88,4 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20240115164518-848082db2d24

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/abema/go-mp4 v1.1.1
+# github.com/abema/go-mp4 v1.1.1 => github.com/dtrejod/go-mp4 v0.0.0-20231229210554-26cd6eb9eb1a
 ## explicit; go 1.14
 github.com/abema/go-mp4
 github.com/abema/go-mp4/internal/bitio


### PR DESCRIPTION
## Before this PR
I thought we needed to path the list atom in order to find the most accurate date time for moov files. However after some testing, I found most iPhone moov files correctly set the mvhd atom with the relevant creation time date. 

## After this PR
No changes. Just bump to latest go-mp4 pkg. 

~Requires: https://github.com/abema/go-mp4/pull/159~