### PR TITLE
improvement: Add support for AVI media.

### DIFF
--- a/internal/mediasort/builder.go
+++ b/internal/mediasort/builder.go
@@ -23,6 +23,7 @@ var (
 		mediatype.TIFF{}.String(),
 		mediatype.QTFF{}.String(),
 		mediatype.MP4{}.String(),
+		mediatype.AVI{}.String(),
 	}
 	// DefaultBlocklist are default regexes that are ignored by the sorter.
 	DefaultBlocklist = []*regexp.Regexp{

--- a/internal/mediatype/avi.go
+++ b/internal/mediatype/avi.go
@@ -1,0 +1,24 @@
+package mediatype
+
+// AVI indetifies AVI media
+// REF: https://en.wikipedia.org/wiki/Audio_Video_Interleave
+type AVI struct {
+	Path string
+}
+
+// String implements Stringer interface
+func (t AVI) String() string {
+	return "avi"
+}
+
+// Ext returns the file extension
+func (t AVI) Ext() string {
+	return "." + t.String()
+}
+
+// Aliases returns known file type aliases for this media type
+func (t AVI) Aliases() map[string]struct{} {
+	return map[string]struct{}{
+		t.String(): {},
+	}
+}

--- a/internal/mediatype/formats.go
+++ b/internal/mediatype/formats.go
@@ -14,6 +14,7 @@ type Format struct {
 	tiff TIFF
 	mov  QTFF
 	mp4  MP4
+	avi  AVI
 }
 
 type mediaFormat string
@@ -25,6 +26,7 @@ const (
 	tiffMediaFormat mediaFormat = "tiff"
 	qtffMediaFormat mediaFormat = "qtff"
 	mp4MediaFormat  mediaFormat = "mp4"
+	aviMediaFormat  mediaFormat = "avi"
 )
 
 // NewJPEGFormat returns a new JPEG format
@@ -57,6 +59,11 @@ func NewMP4Format(h MP4) Format {
 	return Format{t: mp4MediaFormat, mp4: h}
 }
 
+// NewAVIFormat returns a new MPEG-4 format
+func NewAVIFormat(h AVI) Format {
+	return Format{t: aviMediaFormat, avi: h}
+}
+
 // FormatWithVisitor is a generic Format union type visitor
 type FormatWithVisitor[T any] Format
 
@@ -75,6 +82,8 @@ func (f *FormatWithVisitor[T]) Accept(ctx context.Context, v VisitorFunc[T]) (T,
 		return v.VisitQTFF(ctx, f.mov)
 	case mp4MediaFormat:
 		return v.VisitMP4(ctx, f.mp4)
+	case aviMediaFormat:
+		return v.VisitAVI(ctx, f.avi)
 	default:
 		return *new(T), fmt.Errorf("unknown media type")
 	}
@@ -88,6 +97,7 @@ type VisitorFunc[T any] interface {
 	VisitTIFF(context.Context, TIFF) (T, error)
 	VisitQTFF(context.Context, QTFF) (T, error)
 	VisitMP4(context.Context, MP4) (T, error)
+	VisitAVI(context.Context, AVI) (T, error)
 }
 
 // EqualFormats returns true if two Formats are the same type

--- a/internal/mediatype/id.go
+++ b/internal/mediatype/id.go
@@ -34,6 +34,8 @@ func ID(path string, useSignature bool) (Format, error) {
 		return NewQTFFFormat(QTFF{Path: path}), nil
 	case contains(MP4{}.Aliases(), ext):
 		return NewMP4Format(MP4{Path: path}), nil
+	case contains(AVI{}.Aliases(), ext):
+		return NewAVIFormat(AVI{Path: path}), nil
 	default:
 		return Format{}, nil
 	}

--- a/internal/riffdata/riff.go
+++ b/internal/riffdata/riff.go
@@ -1,0 +1,94 @@
+package riffdata
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"time"
+
+	"github.com/go-errors/errors"
+	"golang.org/x/image/riff"
+)
+
+const (
+	// riffIDITDateLayout is the string time layout used by the IDIT chunk
+	riffIDITDateLayout = time.ANSIC
+)
+
+var (
+	// idit is the riff tag associated with the DateTimeOriginal riff tag
+	// Ref: https://exiftool.org/TagNames/RIFF.html
+	idit = riff.FourCC{'I', 'D', 'I', 'T'}
+)
+
+// GetTime returns the RIFF metadata Datetime from media referenced in the provided path
+func GetTime(path string) (time.Time, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return time.Time{}, err
+	}
+	defer f.Close()
+
+	_, r, err := riff.NewReader(f)
+	if err != nil {
+		return time.Time{}, errors.WrapPrefix(err, "could not open file with RIFF reader", 0)
+	}
+	t, found, err := dumpTimeFromReader(r)
+	if err != nil {
+		return time.Time{}, errors.WrapPrefix(err, "unexpected error parsing datetime from RIFF metadata", 0)
+	}
+	if !found {
+		return time.Time{}, errors.New("could not find datetime in RIFF metadata")
+	}
+	return t, nil
+}
+
+func dumpTimeFromReader(r *riff.Reader) (time.Time, bool, error) {
+	for {
+		chunkID, chunkLen, chunkData, err := r.Next()
+		if err == io.EOF {
+			return time.Time{}, false, nil
+		}
+		if err != nil {
+			return time.Time{}, false, err
+		}
+
+		switch chunkID {
+		case riff.LIST:
+			_, listChunk, err := riff.NewListReader(chunkLen, chunkData)
+			if err != nil {
+				return time.Time{}, false, err
+			}
+			t, found, err := dumpTimeFromReader(listChunk)
+			if err != nil {
+				return time.Time{}, false, err
+			}
+			if !found {
+				continue
+			}
+			return t, true, nil
+		case idit:
+			t, err := getTimeFromReader(chunkData, chunkLen)
+			return t, true, err
+		}
+	}
+}
+
+func getTimeFromReader(r io.Reader, chunkLen uint32) (time.Time, error) {
+	buf := bytes.NewBuffer(make([]byte, 0, chunkLen))
+	_, err := io.Copy(buf, r)
+	if err != nil {
+		return time.Time{}, errors.WrapPrefix(err, "failed to copy RIFF IDIT tag into buffer", 0)
+	}
+
+	// IDIT chunk is both line feed and null char terminated
+	val := string(bytes.TrimRight(buf.Bytes(), "\x0a\x00"))
+
+	// Parse string into Time
+	// TODO: Parse timezone
+	t, err := time.Parse(riffIDITDateLayout, val)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return t.UTC(), nil
+}

--- a/internal/riffdata/riff.go
+++ b/internal/riffdata/riff.go
@@ -85,7 +85,6 @@ func getTimeFromReader(r io.Reader, chunkLen uint32) (time.Time, error) {
 	val := string(bytes.TrimRight(buf.Bytes(), "\x0a\x00"))
 
 	// Parse string into Time
-	// TODO: Parse timezone
 	t, err := time.Parse(riffIDITDateLayout, val)
 	if err != nil {
 		return time.Time{}, err

--- a/internal/visitors/duplicate_detector.go
+++ b/internal/visitors/duplicate_detector.go
@@ -69,6 +69,10 @@ func (m *mediaCompare) VisitMP4(ctx context.Context, outMedia mediatype.MP4) (bo
 	return compareUsingSHA256(ctx, m.srcPath, outMedia.Path)
 }
 
+func (m *mediaCompare) VisitAVI(ctx context.Context, outMedia mediatype.AVI) (bool, error) {
+	return compareUsingSHA256(ctx, m.srcPath, outMedia.Path)
+}
+
 func compareUsingPHash(ctx context.Context, src, dest string) (bool, error) {
 	logger := ilog.FromContext(ctx).With(
 		zap.String("sourcePath", src),

--- a/internal/visitors/media_ext.go
+++ b/internal/visitors/media_ext.go
@@ -36,3 +36,7 @@ func (m *mediaExt) VisitQTFF(_ context.Context, media mediatype.QTFF) (map[strin
 func (m *mediaExt) VisitMP4(_ context.Context, media mediatype.MP4) (map[string]struct{}, error) {
 	return media.Aliases(), nil
 }
+
+func (m *mediaExt) VisitAVI(_ context.Context, media mediatype.AVI) (map[string]struct{}, error) {
+	return media.Aliases(), nil
+}

--- a/internal/visitors/media_path.go
+++ b/internal/visitors/media_path.go
@@ -36,3 +36,7 @@ func (m *mediaPath) VisitQTFF(_ context.Context, media mediatype.QTFF) (string, 
 func (m *mediaPath) VisitMP4(_ context.Context, media mediatype.MP4) (string, error) {
 	return media.Path, nil
 }
+
+func (m *mediaPath) VisitAVI(_ context.Context, media mediatype.AVI) (string, error) {
+	return media.Path, nil
+}

--- a/internal/visitors/metadata.go
+++ b/internal/visitors/metadata.go
@@ -54,37 +54,37 @@ func NewMediaMetadataFilename(
 }
 
 func (e *mediaMetadataFilename) VisitJPEG(ctx context.Context, image mediatype.JPEG) (MediaMetadata, error) {
-	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadataWithFunc(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 // VisitPNG implements VisitorFunc
 // EXIF extension was adopted for PNG in 2017
 // http://ftp-osl.osuosl.org/pub/libpng/documents/pngext-1.5.0.html#C.eXIf
 func (e *mediaMetadataFilename) VisitPNG(ctx context.Context, image mediatype.PNG) (MediaMetadata, error) {
-	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadataWithFunc(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitHEIF(ctx context.Context, image mediatype.HEIF) (MediaMetadata, error) {
-	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadataWithFunc(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitTIFF(ctx context.Context, image mediatype.TIFF) (MediaMetadata, error) {
-	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadataWithFunc(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitQTFF(ctx context.Context, image mediatype.QTFF) (MediaMetadata, error) {
-	return e.getTimeMetadatadata(ctx, image.Path, moovdata.GetTime, image.Ext())
+	return e.getTimeMetadataWithFunc(ctx, image.Path, moovdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitMP4(ctx context.Context, image mediatype.MP4) (MediaMetadata, error) {
-	return e.getTimeMetadatadata(ctx, image.Path, moovdata.GetTime, image.Ext())
+	return e.getTimeMetadataWithFunc(ctx, image.Path, moovdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitAVI(ctx context.Context, image mediatype.AVI) (MediaMetadata, error) {
-	return e.getTimeMetadatadata(ctx, image.Path, riffdata.GetTime, image.Ext())
+	return e.getTimeMetadataWithFunc(ctx, image.Path, riffdata.GetTime, image.Ext())
 }
 
-func (e *mediaMetadataFilename) getTimeMetadatadata(
+func (e *mediaMetadataFilename) getTimeMetadataWithFunc(
 	ctx context.Context,
 	srcPath string,
 	tsFunc func(string) (time.Time, error),

--- a/internal/visitors/metadata.go
+++ b/internal/visitors/metadata.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dtrejod/goexif/internal/exifdata"
 	"github.com/dtrejod/goexif/internal/mediatype"
 	"github.com/dtrejod/goexif/internal/moovdata"
+	"github.com/dtrejod/goexif/internal/riffdata"
 )
 
 const (
@@ -53,33 +54,37 @@ func NewMediaMetadataFilename(
 }
 
 func (e *mediaMetadataFilename) VisitJPEG(ctx context.Context, image mediatype.JPEG) (MediaMetadata, error) {
-	return e.getEXIFMetadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 // VisitPNG implements VisitorFunc
 // EXIF extension was adopted for PNG in 2017
 // http://ftp-osl.osuosl.org/pub/libpng/documents/pngext-1.5.0.html#C.eXIf
 func (e *mediaMetadataFilename) VisitPNG(ctx context.Context, image mediatype.PNG) (MediaMetadata, error) {
-	return e.getEXIFMetadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitHEIF(ctx context.Context, image mediatype.HEIF) (MediaMetadata, error) {
-	return e.getEXIFMetadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitTIFF(ctx context.Context, image mediatype.TIFF) (MediaMetadata, error) {
-	return e.getEXIFMetadata(ctx, image.Path, exifdata.GetTime, image.Ext())
+	return e.getTimeMetadatadata(ctx, image.Path, exifdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitQTFF(ctx context.Context, image mediatype.QTFF) (MediaMetadata, error) {
-	return e.getEXIFMetadata(ctx, image.Path, moovdata.GetTime, image.Ext())
+	return e.getTimeMetadatadata(ctx, image.Path, moovdata.GetTime, image.Ext())
 }
 
 func (e *mediaMetadataFilename) VisitMP4(ctx context.Context, image mediatype.MP4) (MediaMetadata, error) {
-	return e.getEXIFMetadata(ctx, image.Path, moovdata.GetTime, image.Ext())
+	return e.getTimeMetadatadata(ctx, image.Path, moovdata.GetTime, image.Ext())
 }
 
-func (e *mediaMetadataFilename) getEXIFMetadata(
+func (e *mediaMetadataFilename) VisitAVI(ctx context.Context, image mediatype.AVI) (MediaMetadata, error) {
+	return e.getTimeMetadatadata(ctx, image.Path, riffdata.GetTime, image.Ext())
+}
+
+func (e *mediaMetadataFilename) getTimeMetadatadata(
 	ctx context.Context,
 	srcPath string,
 	tsFunc func(string) (time.Time, error),

--- a/vendor/golang.org/x/image/riff/riff.go
+++ b/vendor/golang.org/x/image/riff/riff.go
@@ -1,0 +1,193 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package riff implements the Resource Interchange File Format, used by media
+// formats such as AVI, WAVE and WEBP.
+//
+// A RIFF stream contains a sequence of chunks. Each chunk consists of an 8-byte
+// header (containing a 4-byte chunk type and a 4-byte chunk length), the chunk
+// data (presented as an io.Reader), and some padding bytes.
+//
+// A detailed description of the format is at
+// http://www.tactilemedia.com/info/MCI_Control_Info.html
+package riff // import "golang.org/x/image/riff"
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"math"
+)
+
+var (
+	errMissingPaddingByte     = errors.New("riff: missing padding byte")
+	errMissingRIFFChunkHeader = errors.New("riff: missing RIFF chunk header")
+	errListSubchunkTooLong    = errors.New("riff: list subchunk too long")
+	errShortChunkData         = errors.New("riff: short chunk data")
+	errShortChunkHeader       = errors.New("riff: short chunk header")
+	errStaleReader            = errors.New("riff: stale reader")
+)
+
+// u32 decodes the first four bytes of b as a little-endian integer.
+func u32(b []byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}
+
+const chunkHeaderSize = 8
+
+// FourCC is a four character code.
+type FourCC [4]byte
+
+// LIST is the "LIST" FourCC.
+var LIST = FourCC{'L', 'I', 'S', 'T'}
+
+// NewReader returns the RIFF stream's form type, such as "AVI " or "WAVE", and
+// its chunks as a *Reader.
+func NewReader(r io.Reader) (formType FourCC, data *Reader, err error) {
+	var buf [chunkHeaderSize]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			err = errMissingRIFFChunkHeader
+		}
+		return FourCC{}, nil, err
+	}
+	if buf[0] != 'R' || buf[1] != 'I' || buf[2] != 'F' || buf[3] != 'F' {
+		return FourCC{}, nil, errMissingRIFFChunkHeader
+	}
+	return NewListReader(u32(buf[4:]), r)
+}
+
+// NewListReader returns a LIST chunk's list type, such as "movi" or "wavl",
+// and its chunks as a *Reader.
+func NewListReader(chunkLen uint32, chunkData io.Reader) (listType FourCC, data *Reader, err error) {
+	if chunkLen < 4 {
+		return FourCC{}, nil, errShortChunkData
+	}
+	z := &Reader{r: chunkData}
+	if _, err := io.ReadFull(chunkData, z.buf[:4]); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			err = errShortChunkData
+		}
+		return FourCC{}, nil, err
+	}
+	z.totalLen = chunkLen - 4
+	return FourCC{z.buf[0], z.buf[1], z.buf[2], z.buf[3]}, z, nil
+}
+
+// Reader reads chunks from an underlying io.Reader.
+type Reader struct {
+	r   io.Reader
+	err error
+
+	totalLen uint32
+	chunkLen uint32
+
+	chunkReader *chunkReader
+	buf         [chunkHeaderSize]byte
+	padded      bool
+}
+
+// Next returns the next chunk's ID, length and data. It returns io.EOF if there
+// are no more chunks. The io.Reader returned becomes stale after the next Next
+// call, and should no longer be used.
+//
+// It is valid to call Next even if all of the previous chunk's data has not
+// been read.
+func (z *Reader) Next() (chunkID FourCC, chunkLen uint32, chunkData io.Reader, err error) {
+	if z.err != nil {
+		return FourCC{}, 0, nil, z.err
+	}
+
+	// Drain the rest of the previous chunk.
+	if z.chunkLen != 0 {
+		want := z.chunkLen
+		var got int64
+		got, z.err = io.Copy(ioutil.Discard, z.chunkReader)
+		if z.err == nil && uint32(got) != want {
+			z.err = errShortChunkData
+		}
+		if z.err != nil {
+			return FourCC{}, 0, nil, z.err
+		}
+	}
+	z.chunkReader = nil
+	if z.padded {
+		if z.totalLen == 0 {
+			z.err = errListSubchunkTooLong
+			return FourCC{}, 0, nil, z.err
+		}
+		z.totalLen--
+		_, z.err = io.ReadFull(z.r, z.buf[:1])
+		if z.err != nil {
+			if z.err == io.EOF {
+				z.err = errMissingPaddingByte
+			}
+			return FourCC{}, 0, nil, z.err
+		}
+	}
+
+	// We are done if we have no more data.
+	if z.totalLen == 0 {
+		z.err = io.EOF
+		return FourCC{}, 0, nil, z.err
+	}
+
+	// Read the next chunk header.
+	if z.totalLen < chunkHeaderSize {
+		z.err = errShortChunkHeader
+		return FourCC{}, 0, nil, z.err
+	}
+	z.totalLen -= chunkHeaderSize
+	if _, z.err = io.ReadFull(z.r, z.buf[:chunkHeaderSize]); z.err != nil {
+		if z.err == io.EOF || z.err == io.ErrUnexpectedEOF {
+			z.err = errShortChunkHeader
+		}
+		return FourCC{}, 0, nil, z.err
+	}
+	chunkID = FourCC{z.buf[0], z.buf[1], z.buf[2], z.buf[3]}
+	z.chunkLen = u32(z.buf[4:])
+	if z.chunkLen > z.totalLen {
+		z.err = errListSubchunkTooLong
+		return FourCC{}, 0, nil, z.err
+	}
+	z.padded = z.chunkLen&1 == 1
+	z.chunkReader = &chunkReader{z}
+	return chunkID, z.chunkLen, z.chunkReader, nil
+}
+
+type chunkReader struct {
+	z *Reader
+}
+
+func (c *chunkReader) Read(p []byte) (int, error) {
+	if c != c.z.chunkReader {
+		return 0, errStaleReader
+	}
+	z := c.z
+	if z.err != nil {
+		if z.err == io.EOF {
+			return 0, errStaleReader
+		}
+		return 0, z.err
+	}
+
+	n := int(z.chunkLen)
+	if n == 0 {
+		return 0, io.EOF
+	}
+	if n < 0 {
+		// Converting uint32 to int overflowed.
+		n = math.MaxInt32
+	}
+	if n > len(p) {
+		n = len(p)
+	}
+	n, err := z.r.Read(p[:n])
+	z.totalLen -= uint32(n)
+	z.chunkLen -= uint32(n)
+	if err != io.EOF {
+		z.err = err
+	}
+	return n, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -77,6 +77,7 @@ go.uber.org/zap/zapcore
 # golang.org/x/image v0.14.0
 ## explicit; go 1.18
 golang.org/x/image/ccitt
+golang.org/x/image/riff
 golang.org/x/image/tiff
 golang.org/x/image/tiff/lzw
 # golang.org/x/net v0.0.0-20221002022538-bcab6841153b


### PR DESCRIPTION
## Before this PR
`./goexif` would error on AVI media files with the `unknown media type` error.

## After this PR
Adds support for parsing DateTime from AVI media files. We parse the RIFF IDIT tag in order to determine the DateTime from AVI media files. 
