### PR TITLE
fix: Use known aliases for default support media types.

### DIFF
--- a/internal/mediasort/init.go
+++ b/internal/mediasort/init.go
@@ -11,6 +11,8 @@ var (
 // init initializes the FileTypes variable
 func init() {
 	for _, media := range mediatype.AllKnownMediaTypes {
-		DefaultFileTypes = append(DefaultFileTypes, media.String())
+		for alias := range media.Aliases() {
+			DefaultFileTypes = append(DefaultFileTypes, alias)
+		}
 	}
 }


### PR DESCRIPTION
## Before this PR

The default media types ignored known aliases of support media types

## After this PR

We process by default all known aliases. 